### PR TITLE
Bump python from 3.9.1 to 3.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1
+FROM python:3.9.2
 
 WORKDIR /code
 VOLUME /data


### PR DESCRIPTION
Bumps python from 3.9.1 to 3.9.2.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>